### PR TITLE
Fix meta description tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="%PUBLIC_URL%/marc.jpg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="Marc Singer" content="Marc Singer's personal website" />
+    <meta name="description" content="Marc Singer's personal website" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/marc.jpg" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Marc Singer</title>


### PR DESCRIPTION
## Summary
- use the standard HTML description meta tag

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_685998c3c4148320be2e95f49e5047f7